### PR TITLE
fix: commented out nonexistent "precision" field in API header

### DIFF
--- a/generator/api.v
+++ b/generator/api.v
@@ -120,7 +120,7 @@ pub mut:
 		version_status    string @[required]
 		version_build     string @[required]
 		version_full_name string @[required]
-		precision         string @[required]
+		//precision         string @[required]
 	} @[required]
 
 	builtin_class_sizes []struct {


### PR DESCRIPTION
Since there's no "precision" in the "header" of extension_api.json, but there's field "precision" field in the header struct of the API struct in api.v, it was not possible to generate bindings. So I've commented out nonexistend field, and it resolved #24.